### PR TITLE
Tag requests with ip address

### DIFF
--- a/collector/handler.go
+++ b/collector/handler.go
@@ -10,6 +10,8 @@ import (
 	"github.com/99designs/telemetry"
 	"github.com/gorilla/context"
 	"github.com/gorilla/mux"
+	"net"
+	"strings"
 )
 
 const ContextKey = "telemetry_context"
@@ -19,8 +21,12 @@ func Gorilla(c *telemetry.Context, router *mux.Router, next http.Handler) http.H
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 
+		// IPv6 addresses use colons, but they are the tag separator. Lets use dots instead.
+		ip := strings.Replace(getIp(r), ":", ".", -1)
+
 		routeContext := c.SubContext(
 			"route:" + getRouteName(router, r),
+			"ip:" + ip,
 		)
 
 		context.Set(r, ContextKey, routeContext)
@@ -56,6 +62,22 @@ func getRouteName(router *mux.Router, r *http.Request) string {
 	} else {
 		return "unknown"
 	}
+}
+
+// getIp returns the last non-private X-Forwarded-For header otherwise the requests remote address
+func getIp(r *http.Request) string {
+	for _, xff := range r.Header["X-Forwarded-For"] {
+		addresses := strings.Split(strings.Replace(xff, " ", ",", -1), ",")
+
+		for i := len(addresses) -1 ; i >= 0; i-- {
+			xffIp := net.ParseIP(addresses[i])
+			if xffIp != nil && !privateIP(xffIp) {
+				return xffIp.String()
+			}
+		}
+	}
+
+	return net.ParseIP(strings.Split(r.RemoteAddr, ":")[0]).String()
 }
 
 // There appears to be no good way determine the http code

--- a/collector/ip.go
+++ b/collector/ip.go
@@ -1,0 +1,39 @@
+package collector
+
+import (
+	"net"
+)
+
+func mustCIDR(cidr string) net.IPNet {
+	_, net, err := net.ParseCIDR(cidr)
+	if err != nil {
+		panic(err)
+	}
+
+	return *net
+}
+
+var privateNetworks = []net.IPNet{
+	mustCIDR("10.0.0.0/8"),
+	mustCIDR("100.64.0.0/10"),
+	mustCIDR("100.64.0.0/10"),
+	mustCIDR("127.0.0.0/8"),
+	mustCIDR("169.254.0.0/16"),
+	mustCIDR("172.16.0.0/12"),
+	mustCIDR("192.0.0.0/24"),
+	mustCIDR("192.0.2.0/24"),
+	mustCIDR("192.168.0.0/16"),
+	mustCIDR("192.18.0.0/15"),
+	mustCIDR("fc00::/7"),
+	mustCIDR("fe80::/10"),
+}
+
+func privateIP(ip net.IP) bool {
+	for _, net := range privateNetworks {
+		if net.Contains(ip) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/collector/ip_test.go
+++ b/collector/ip_test.go
@@ -1,0 +1,29 @@
+package collector
+
+import (
+	"testing"
+	"net"
+)
+
+func TestPrivateIp(t *testing.T) {
+	checks := map[string]bool {
+		"192.168.1.1": true,
+		"8.8.8.8": false,
+		"172.16.100.0": true,
+		"172.32.1.1": false,
+		"10.0.0.1": true,
+		"10.255.255.254": true,
+		"dead:beef:cafe:f00d:dead:beef:cafe:f00d": false,
+		"fc00:beef:cafe:f00d:dead:beef:cafe:f00d": true,
+	}
+
+	for ip, isPrivate := range checks {
+		if privateIP(net.ParseIP(ip)) != isPrivate {
+			str := "not private"
+			if !isPrivate {
+				str = "private"
+			}
+			t.Errorf("%s is icorrectly marked as %s", ip, str)
+		}
+	}
+}


### PR DESCRIPTION
Extracts the source IP address from the x-forwarded-for header or the request RemoteAddr and tags each request with it.

Should be v4 and v6 safe.
