### PR TITLE
Move gorilla to subpackage

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ gorilla
 router := mux.NewRouter()
 router.Handle("/", handler).Name("test.route")
 
-handler := collector.Gorilla(t, router, func(w http.ResponseWriter, r *http.Request) {
+handler := gorilla.Handler(t, router, func(w http.ResponseWriter, r *http.Request) {
     // You can log your own metrics from any handler after this.
-    ContextForRequest(r).Gauge("test_metric", 2)
+    gorilla.ContextForRequest(r).Gauge("test_metric", 2)
 })
 ```

--- a/collector/gorilla/handler.go
+++ b/collector/gorilla/handler.go
@@ -1,25 +1,23 @@
-package collector
+package gorilla
 
 import (
+	"bufio"
+	"errors"
+	"net"
 	"net/http"
+	"reflect"
 	"strconv"
 	"time"
-)
 
-import (
 	"github.com/99designs/telemetry"
 	"github.com/gorilla/context"
 	"github.com/gorilla/mux"
-	"bufio"
-	"net"
-	"errors"
-	"reflect"
 )
 
 const ContextKey = "telemetry_context"
 
 // Handler returns middleware to collect request duration/exit status
-func Gorilla(c *telemetry.Context, router *mux.Router, next http.Handler) http.Handler {
+func Handler(c *telemetry.Context, router *mux.Router, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 

--- a/collector/gorilla/handler_test.go
+++ b/collector/gorilla/handler_test.go
@@ -1,4 +1,4 @@
-package collector
+package gorilla
 
 import (
 	"net/http"
@@ -18,7 +18,7 @@ func TestRouteContext(t *testing.T) {
 	})
 
 	s := sink.Test()
-	handler = Gorilla(telemetry.NewContext(s), router, handler)
+	handler = Handler(telemetry.NewContext(s), router, handler)
 	router.Handle("/", handler).Name("test.route")
 
 	doTestGet(router, "/")


### PR DESCRIPTION
By having gorilla in the same package as the runtime collector we force all apps to pull in gorilla. lets put it in a package of its own.