### PR TITLE
Add a direct datadog http sink

### DIFF
--- a/sink/datadog/api.go
+++ b/sink/datadog/api.go
@@ -1,0 +1,68 @@
+package datadog
+
+import (
+	"bytes"
+	"encoding/json"
+	"sort"
+)
+
+type Points map[int64]float64
+
+func (p *Points) UnmarshalJSON(b []byte) error {
+	var tmp [][]interface{}
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.UseNumber()
+
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+
+	*p = map[int64]float64{}
+	for _, kv := range tmp {
+		key, err := kv[0].(json.Number).Int64()
+		if err != nil {
+			return err
+		}
+		(*p)[key], err = kv[1].(json.Number).Float64()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p Points) MarshalJSON() ([]byte, error) {
+	tmp := make([][]interface{}, len(p))
+	i := 0
+	for k, v := range p {
+		tmp[i] = []interface{}{k, v}
+		i++
+	}
+
+	sort.Slice(tmp, func(i, j int) bool {
+		return tmp[i][0].(int64) < tmp[j][0].(int64)
+	})
+
+	return json.Marshal(tmp)
+}
+
+type Series struct {
+	Metric string   `json:"metric"`
+	Points Points   `json:"points"`
+	Type   string   `json:"type"`
+	Tags   []string `json:"tags"`
+	Host   string   `json:"host"`
+}
+
+func (s Series) Copy(suffix string) Series {
+	newS := s
+	newS.Points = Points{}
+	newS.Metric += suffix
+	return newS
+}
+
+type BatchSeries struct {
+	Series []Series `json:"series"`
+}

--- a/sink/datadog/api_test.go
+++ b/sink/datadog/api_test.go
@@ -1,0 +1,22 @@
+package datadog
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPointEncode(t *testing.T) {
+	p := Points{
+		12345678: 32,
+		12345679: 44,
+	}
+
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Error("unexpected error: " + err.Error())
+	}
+
+	if string(b) != "[[12345678,32],[12345679,44]]" {
+		t.Error("unexpected encoding: " + string(b))
+	}
+}

--- a/sink/datadog/http.go
+++ b/sink/datadog/http.go
@@ -1,0 +1,269 @@
+package datadog
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"math"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"os"
+
+	"github.com/99designs/telemetry"
+)
+
+const MAX_POINTS = 100000
+
+var hostname string
+
+func init() {
+	hostname, _ = os.Hostname()
+}
+
+type DirectSink struct {
+	metrics chan singlePoint
+	key     string
+	Client  http.Client
+	points  int64 `json:"-"`
+
+	// [metric name][tags]points
+	buffer map[string]map[string]points
+}
+
+type points struct {
+	// [time]: []samples
+	Values map[int64][]float64
+	Type   string
+}
+
+type singlePoint struct {
+	Metric string
+	Time   int64
+	Value  float64
+	Type   string
+	Tags   []string
+}
+
+// HTTP pushes metrics directly to the datadog http apis. No agent is required.
+func HTTP(key string) telemetry.Sink {
+	sink := &DirectSink{
+		metrics: make(chan singlePoint, 1000),
+		key:     key,
+		Client: http.Client{
+			Timeout: 5 * time.Second,
+		},
+	}
+	sink.Reset()
+
+	ticker := time.NewTicker(time.Second * 10)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				if err := sink.send(); err != nil {
+					log.Printf(err.Error())
+				}
+
+			case point := <-sink.metrics:
+				sink.addPoint(point)
+			}
+		}
+	}()
+
+	return sink
+}
+
+// Count adds a value to a stat
+func (s *DirectSink) Count(c *telemetry.Context, stat string, count float64) {
+	s.writePoint(c, stat, count, "rate")
+}
+
+// Gague sends an absolute value. Useful for tracking things like memory.
+func (s *DirectSink) Gauge(c *telemetry.Context, stat string, value float64) {
+	s.writePoint(c, stat, value, "gauge")
+}
+
+// Histogram measures the statistical distribution of a set of values. eg query time
+func (s *DirectSink) Histogram(c *telemetry.Context, stat string, value float64) {
+	s.writePoint(c, stat, value, "hist")
+}
+
+// Timing is a special subclass of Histgram for timing information.
+func (s *DirectSink) Timing(c *telemetry.Context, stat string, value float64) {
+	s.writePoint(c, stat, value, "timing")
+}
+
+// Set counts unique values. Send user id to monitor unique users.
+func (s *DirectSink) Set(c *telemetry.Context, stat string, value float64) {
+	s.writePoint(c, stat, value, "set")
+}
+
+func (s *DirectSink) buildBatch() *BatchSeries {
+	bs := BatchSeries{}
+
+	for metric, tags := range s.buffer {
+		for tagstr, inSeries := range tags {
+			outSeries := Series{
+				Type:   inSeries.Type,
+				Metric: metric,
+				Tags:   strings.Split(tagstr, ","),
+				Points: Points{},
+				Host:   hostname,
+			}
+
+			switch inSeries.Type {
+			case "rate": // take the sum of all points
+				outSeries.Type = "rate"
+				for time, points := range inSeries.Values {
+					var val float64 = 0
+					for _, v := range points {
+						val += v
+					}
+					outSeries.Points[time] = val
+				}
+
+				bs.Series = append(bs.Series, outSeries)
+
+			case "gauge": // take the last value
+				outSeries.Type = "gauge"
+				for time, points := range inSeries.Values {
+					outSeries.Points[time] = points[len(points)-1]
+				}
+
+				bs.Series = append(bs.Series, outSeries)
+
+			case "set": // count the distinct entries
+				outSeries.Type = "gauge"
+				for time, points := range inSeries.Values {
+					counts := map[float64]int{}
+					for _, v := range points {
+						counts[v]++
+					}
+					outSeries.Points[time] = float64(len(counts))
+					bs.Series = append(bs.Series, outSeries)
+				}
+
+			case "hist", "timing": // send aggregate stats
+				outSeries.Type = "gauge"
+
+				avgSeries := outSeries.Copy(".avg")
+				minSeries := outSeries.Copy(".min")
+				maxSeries := outSeries.Copy(".max")
+				countSeries := outSeries.Copy(".count")
+				countSeries.Type = "rate"
+
+				for time, points := range inSeries.Values {
+					var sum, count, min, max float64 = 0, 0, math.Inf(1), math.Inf(-1)
+					for _, v := range points {
+						sum += v
+						count += 1
+						if v < min {
+							min = v
+						}
+						if v > max {
+							max = v
+						}
+					}
+					avgSeries.Points[time] = sum / count
+					countSeries.Points[time] = count
+					minSeries.Points[time] = min
+					maxSeries.Points[time] = max
+				}
+
+				bs.Series = append(bs.Series, avgSeries)
+				bs.Series = append(bs.Series, countSeries)
+				bs.Series = append(bs.Series, minSeries)
+				bs.Series = append(bs.Series, maxSeries)
+			}
+		}
+	}
+
+	sort.Slice(bs.Series, func(i, j int) bool {
+		return strings.Compare(bs.Series[i].Metric, bs.Series[j].Metric) > 0
+	})
+
+	return &bs
+}
+
+func (s *DirectSink) send() error {
+	if len(s.buffer) == 0 {
+		return nil
+	}
+
+	bs := s.buildBatch()
+	body, err := json.Marshal(bs)
+	if err != nil {
+		panic(err)
+	}
+
+	req, err := http.NewRequest("POST", "https://app.datadoghq.com/api/v1/series?api_key="+s.key, bytes.NewReader(body))
+	if err != nil {
+		panic(err)
+	}
+	resp, err := s.Client.Do(req)
+	if err != nil {
+		return errors.New("error posting metrics to datadog: " + err.Error())
+	}
+
+	if resp.StatusCode != http.StatusAccepted {
+		b, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("error posting metrics to datadog status=%d: %s", resp.StatusCode, string(b))
+	}
+
+	err = resp.Body.Close()
+	if err != nil {
+		panic(err)
+	}
+
+	s.Reset()
+
+	return nil
+}
+
+func (s *DirectSink) Reset() {
+	s.points = 0
+	s.buffer = map[string]map[string]points{}
+}
+
+func (s *DirectSink) addPoint(point singlePoint) {
+	if s.points >= MAX_POINTS {
+		if s.points == MAX_POINTS {
+			log.Printf("datadog hit MAX_POINTS. is datadog down? dropping metrics to keep app running.")
+		}
+		return
+	}
+	s.points++
+
+	if s.buffer[point.Metric] == nil {
+		s.buffer[point.Metric] = map[string]points{}
+	}
+
+	tagstr := strings.Join(point.Tags, ",")
+	points := s.buffer[point.Metric][tagstr]
+	points.Type = point.Type
+	if points.Values == nil {
+		points.Values = map[int64][]float64{}
+	}
+	points.Values[point.Time] = append(points.Values[point.Time], point.Value)
+	s.buffer[point.Metric][tagstr] = points
+}
+
+func (s *DirectSink) writePoint(c *telemetry.Context, stat string, value float64, typ string) {
+	select {
+	case s.metrics <- singlePoint{
+		Tags:   c.Tags(),
+		Type:   typ,
+		Metric: stat,
+		Time:   time.Now().Unix(),
+		Value:  value,
+	}:
+	default:
+		log.Printf("dropping metric %s due channel overflow. DD outage?", stat)
+	}
+}

--- a/sink/datadog/http_test.go
+++ b/sink/datadog/http_test.go
@@ -1,0 +1,229 @@
+package datadog
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/99designs/telemetry"
+	"github.com/stretchr/testify/require"
+)
+
+type tripperFunc func(*http.Request) (*http.Response, error)
+
+func (t tripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return t(r) }
+
+func TestSink(t *testing.T) {
+	sink := testSink()
+	ctx := telemetry.NewContext(sink).SubContext("tag:test")
+
+	t.Run("test rate", func(t *testing.T) {
+		sink.Count(ctx, "test.rate", 1)
+		sink.Count(ctx, "test.rate", 1)
+		sink.Count(ctx, "test.rate", -1)
+		sink.Count(ctx, "test.rate", 1)
+		pumpAll(sink)
+
+		require.Equal(t, "test.rate", sink.buildBatch().Series[0].Metric)
+		require.Equal(t, 2.0, sink.buildBatch().Series[0].Points[time.Now().Unix()])
+	})
+
+	sink.Reset()
+
+	t.Run("test gauge", func(t *testing.T) {
+		sink.Gauge(ctx, "test.gauge", 12.3)
+		sink.Gauge(ctx, "test.gauge", 12.4)
+		pumpAll(sink)
+
+		require.Equal(t, "test.gauge", sink.buildBatch().Series[0].Metric)
+		require.Equal(t, 12.4, sink.buildBatch().Series[0].Points[time.Now().Unix()])
+	})
+
+	sink.Reset()
+
+	t.Run("test set", func(t *testing.T) {
+		sink.Set(ctx, "test.set", 1)
+		sink.Set(ctx, "test.set", 2)
+		sink.Set(ctx, "test.set", 2)
+		sink.Set(ctx, "test.set", 5)
+		pumpAll(sink)
+
+		require.Equal(t, "test.set", sink.buildBatch().Series[0].Metric)
+		require.Equal(t, 3.0, sink.buildBatch().Series[0].Points[time.Now().Unix()])
+	})
+
+	sink.Reset()
+
+	t.Run("test hist", func(t *testing.T) {
+		sink.Histogram(ctx, "test.hist", 1)
+		sink.Histogram(ctx, "test.hist", 2)
+		sink.Histogram(ctx, "test.hist", 2)
+		sink.Histogram(ctx, "test.hist", 3)
+		pumpAll(sink)
+
+		series := sink.buildBatch().Series
+
+		require.Equal(t, "test.hist.min", series[0].Metric)
+		require.Equal(t, 1.0, series[0].Points[time.Now().Unix()])
+		require.Equal(t, "test.hist.max", series[1].Metric)
+		require.Equal(t, 3.0, series[1].Points[time.Now().Unix()])
+
+		require.Equal(t, "test.hist.count", series[2].Metric)
+		require.Equal(t, 4.0, series[2].Points[time.Now().Unix()])
+		require.Equal(t, "test.hist.avg", series[3].Metric)
+		require.Equal(t, 2.0, series[3].Points[time.Now().Unix()])
+
+	})
+
+	sink.Reset()
+
+	t.Run("test serialize", func(t *testing.T) {
+		sink.Count(ctx, "test.rate", 1)
+		sink.Count(ctx, "test.rate", 1)
+		sink.Count(ctx, "test.rate", -1)
+		sink.Count(ctx, "test.rate", 1)
+
+		sink.Set(ctx, "test.set", 1)
+		sink.Set(ctx, "test.set", 2)
+		sink.Set(ctx, "test.set", 2)
+		sink.Set(ctx, "test.set", 5)
+
+		sink.Gauge(ctx, "test.gauge", 12.3)
+		sink.Gauge(ctx, "test.gauge", 12.4)
+
+		sink.Histogram(ctx, "test.hist", 1)
+		sink.Histogram(ctx, "test.hist", 2)
+		sink.Histogram(ctx, "test.hist", 2)
+		sink.Histogram(ctx, "test.hist", 3)
+
+		sink.Timing(ctx, "test.timing", 1)
+		sink.Timing(ctx, "test.timing", 2)
+		sink.Timing(ctx, "test.timing", 2)
+		sink.Timing(ctx, "test.timing", 3)
+
+		pumpAll(sink)
+
+		sink.Client.Transport = tripperFunc(func(r *http.Request) (*http.Response, error) {
+			b, _ := ioutil.ReadAll(r.Body)
+
+			bs := BatchSeries{}
+			err := json.Unmarshal(b, &bs)
+			if err != nil {
+				panic(err)
+			}
+
+			now := time.Now().Unix()
+
+			expected := BatchSeries{
+				Series: []Series{
+					{
+						Metric: "test.timing.min",
+						Points: Points{now: 1},
+						Type:   "gauge",
+						Tags:   []string{"tag:test"},
+						Host:   hostname,
+					}, {
+						Metric: "test.timing.max",
+						Points: Points{now: 3},
+						Type:   "gauge",
+						Tags:   []string{"tag:test"},
+						Host:   hostname,
+					}, {
+						Metric: "test.timing.count",
+						Points: Points{now: 4},
+						Type:   "rate",
+						Tags:   []string{"tag:test"},
+						Host:   hostname,
+					}, {
+						Metric: "test.timing.avg",
+						Points: Points{now: 2},
+						Type:   "gauge",
+						Tags:   []string{"tag:test"},
+						Host:   hostname,
+					}, {
+						Metric: "test.set",
+						Points: Points{now: 3},
+						Type:   "gauge",
+						Tags:   []string{"tag:test"},
+						Host:   hostname,
+					}, {
+						Metric: "test.rate",
+						Points: Points{now: 2},
+						Type:   "rate",
+						Tags:   []string{"tag:test"},
+						Host:   hostname,
+					}, {
+						Metric: "test.hist.min",
+						Points: Points{now: 1},
+						Type:   "gauge",
+						Tags:   []string{"tag:test"},
+						Host:   hostname,
+					}, {
+						Metric: "test.hist.max",
+						Points: Points{now: 3},
+						Type:   "gauge",
+						Tags:   []string{"tag:test"},
+						Host:   hostname,
+					}, {
+						Metric: "test.hist.count",
+						Points: Points{now: 4},
+						Type:   "rate",
+						Tags:   []string{"tag:test"},
+						Host:   hostname,
+					}, {
+						Metric: "test.hist.avg",
+						Points: Points{now: 2},
+						Type:   "gauge",
+						Tags:   []string{"tag:test"},
+						Host:   hostname,
+					}, {
+						Metric: "test.gauge",
+						Points: Points{now: 12.4},
+						Type:   "gauge",
+						Tags:   []string{"tag:test"},
+						Host:   hostname,
+					},
+				},
+			}
+
+			require.EqualValues(t, expected, bs)
+
+			return &http.Response{
+				Body: ioutil.NopCloser(&bytes.Buffer{}),
+			}, nil
+		})
+
+		sink.send()
+	})
+}
+
+func testSink() *DirectSink {
+	sink := &DirectSink{
+		metrics: make(chan singlePoint, 1000),
+		Client: http.Client{
+			Timeout: 5 * time.Second,
+		},
+	}
+	sink.Reset()
+
+	return sink
+}
+
+func pumpAll(ds *DirectSink) {
+	n := 0
+	for {
+		select {
+		case point := <-ds.metrics:
+			ds.addPoint(point)
+			n++
+		default:
+			if n == 0 {
+				panic("nothing in channel to pump!")
+			}
+			return
+		}
+	}
+}

--- a/sink/datadog/integration_test.go
+++ b/sink/datadog/integration_test.go
@@ -1,0 +1,49 @@
+package datadog
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/99designs/telemetry"
+	"github.com/99designs/telemetry/collector"
+)
+
+// This test starts logging some fake metrics, but never terminates. Go check the metrics in datadog and manually kill the test.
+func TestHTTPIntegration(t *testing.T) {
+	key := os.Getenv("DD_KEY")
+	if key == "" {
+		t.Skip("DD_KEY must be specified in an env var to run integration tests")
+	}
+
+	sink := HTTP(key).(*DirectSink)
+	sink.Client.Transport = tripperFunc(func(r *http.Request) (*http.Response, error) {
+		b, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			panic(err)
+		}
+
+		r.Body = ioutil.NopCloser(bytes.NewReader(b))
+		fmt.Println("Sending: " + string(b))
+
+		return http.DefaultTransport.RoundTrip(r)
+	})
+	ctx := telemetry.NewContext(sink).SubContext("env:test", "app:telemetry")
+
+	collector.Runtime(ctx)
+
+	for {
+		ctx.Histogram("telemetry.test.hist", rand.Float64())
+		ctx.Timing("telemetry.test.timing", rand.Float64())
+		ctx.Count("telemetry.test.count", float64(rand.Int()%3-1))
+		ctx.Gauge("telemetry.test.gauge", rand.Float64())
+		ctx.Set("telemetry.test.set", float64(rand.Int()&30))
+
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/sink/datadog/udp.go
+++ b/sink/datadog/udp.go
@@ -1,4 +1,4 @@
-package sink
+package datadog
 
 import (
 	"log"
@@ -11,7 +11,8 @@ type DatadogSink struct {
 	god *godspeed.Godspeed
 }
 
-func Datadog(host string, port int) (telemetry.Sink, error) {
+// UDP pushes metrics to local dogstatsd / datadog agent
+func UDP(host string, port int) (telemetry.Sink, error) {
 	god, err := godspeed.New(host, port, false)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
https://github.com/DataDog/dd-agent is written in python so would be horrendous to put into an ECS container to run on FARGATE.

the rewrite https://github.com/DataDog/datadog-agent is written in go, but builds to a bunch of different binaries and has no simple binary download (like any other go project release).

The good news is we don't actually need the agent, there is a http api that does exactly what we need - https://docs.datadoghq.com/api/#metrics-post.

This PR adds a new sink that calls that API every 10 seconds, buffering up and aggregating metrics in between.

I've included an integration test that posts some real fake metrics to datadog and they turn up ok:
![image](https://user-images.githubusercontent.com/2247982/33540309-95e2458e-d91e-11e7-81f9-553dfba565a2.png)