### PR TITLE
Add 'support' for WebAssembly

### DIFF
--- a/collector/cpu.go
+++ b/collector/cpu.go
@@ -1,3 +1,5 @@
+// +build !js !wasm
+
 package collector
 
 import (

--- a/collector/disk.go
+++ b/collector/disk.go
@@ -1,3 +1,5 @@
+// +build !js !wasm
+
 package collector
 
 import (

--- a/collector/mem.go
+++ b/collector/mem.go
@@ -1,3 +1,5 @@
+// +build !js !wasm
+
 package collector
 
 import (

--- a/collector/wasm.go
+++ b/collector/wasm.go
@@ -1,0 +1,11 @@
+// +build js,wasm
+
+package collector
+
+import "github.com/99designs/telemetry"
+
+func CPU(tel *telemetry.Context) {}
+
+func Disk(tel *telemetry.Context, path string) {}
+
+func Mem(tel *telemetry.Context) {}


### PR DESCRIPTION
Our runtime CPU, disk and memory stats collectors rely on a bunch of system stuff that isn't in the WebAssembly environment. 

This patch simply makes them do nothing - monitoring like this will likely be done via the webassembly runtime rather than in-process.