### PR TITLE
Update to new preferred fork of godspeed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/99designs/telemetry
 
 go 1.12
 
+replace github.com/theckman/godspeed => github.com/theckman/godspeed-og v1.1.0
+
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/kr/pretty v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,7 +9,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.1.4 h1:ToftOQTytwshuOSj6bDSolVUa3GINfJP/fg3OkkOzQQ=
 github.com/stretchr/testify v1.1.4/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/theckman/godspeed v1.1.0 h1:PJyNf4xeeAMTxf2VFPMBLEEeETTcx804FkIxhd8pkfY=
-github.com/theckman/godspeed v1.1.0/go.mod h1:HbvX1ULDanALaHLD1Q1jwxL3THjMTn6KgpTSZ1MTvMQ=
+github.com/theckman/godspeed-og v1.1.0 h1:7L6E9jgRVRMhZu9g9sZg9PTzm+Zz0smEF6H2KkkDp3U=
+github.com/theckman/godspeed-og v1.1.0/go.mod h1:lk8ZMPzo59IEVUYrGibjoiZXnmsBidyhNIBTJZ5AdA8=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Switch to github.com/theckman/godspeed-og where the v1.1.0 tag now exists.